### PR TITLE
Minor bug fix on setIntensity

### DIFF
--- a/MAX72xx.s2e
+++ b/MAX72xx.s2e
@@ -33,7 +33,7 @@
             "setup":"",
             "inc":"",
             "def":"",
-            "work":"led.setIntensity(0,{1});\n",
+            "work":"led.setIntensity(0,{0});\n",
             "loop":""
          }
       ],


### PR DESCRIPTION
The setIntensity method is corrected. The place holder for the input should be {0}